### PR TITLE
implement inverse method in field element

### DIFF
--- a/src/field/types/base.rs
+++ b/src/field/types/base.rs
@@ -547,4 +547,44 @@ mod tests {
         };
         assert_eq!(expected.value, result.value);
     }
+
+    #[test]
+    fn test_multiplication_near_boundary() {
+        // `PRIME` is the expression `1 + 407 * 2u128.pow(119)` evaluated
+        // see: https://github.com/aszepieniec/stark-anatomy/blob/76c375505a28e7f02f8803f77f8d7620d834071d/docs/basic-tools.md?plain=1#L113-L119
+        //
+        // This test is essential for ensuring the robustness and correctness of our multiplication
+        // implementation, especially when values approach the maximum representable in the I256 type.
+        //
+        // In many cryptographic contexts, especially those that use modular arithmetic (like STARKs),
+        // operations involving numbers near the modulus (in this case, PRIME) are common. This test
+        // simulates a "worst-case scenario" where two values just shy of the modulus are multiplied
+        // together. The results of such multiplications can potentially overflow the I256 type.
+        //
+        // Two things are being checked here:
+        // 1. That the raw multiplication (without considering any modulus) is correct. This checks
+        //    if the system handles potential overflows correctly. The result is compared against a
+        //    saturating multiplication to ensure no unintended wrap-around occurs.
+        // 2. That the multiplication result modulo PRIME is as expected. In modular arithmetic,
+        //    multiplying two numbers both equal to (PRIME - 1) should yield a result of 1 when taken modulo PRIME.
+        //
+        // Ensuring correctness for this boundary condition is crucial for the overall reliability of
+        // any system built on top of this arithmetic foundation.
+
+        // Given the boundary condition where PRIME is close to the maximum value for I256.
+        let prime = 270497897142230380135924736767050121217_u128;
+        let prime_minus_one = prime - 1_u128;
+        let near_boundary = I256::from(prime_minus_one);
+
+        // When
+        let result = near_boundary * near_boundary;
+
+        // Then
+        // Expected result computation depends on the desired behavior.
+        let expected_value = I256::from((prime_minus_one).saturating_mul(prime_minus_one));
+        let mod_prime = expected_value % I256::from(prime);
+
+        assert_eq!(expected_value, result);
+        assert_eq!(I256::ONE, mod_prime);
+    }
 }

--- a/src/field/utils.rs
+++ b/src/field/utils.rs
@@ -17,12 +17,46 @@ pub(crate) fn extended_euclidean(a: I256, b: I256) -> (I256, I256, I256) {
     }
 }
 
+/// Calculates the multiplicative inverse of `a` modulo `m`.
+///
+/// # Arguments
+/// * `a` - The number for which we want to find an inverse.
+/// * `m` - The modulo under which the inverse should be found.
+///
+/// # Returns
+/// * `Option<I256>` - The multiplicative inverse if it exists; `None` if `a` and `m` are not coprime.
+///
+/// # Explanation
+/// Even though `x` is always non-negative in `I256`, it might represent a "negative" value
+/// in the context of modular arithmetic. To ensure our result is in the standard range [0, m-1],
+/// the following steps are performed:
+///
+/// 1. (x % m): This operation takes `x` modulo `m`.
+///    * If `x` is positive, the result is in [0, m-1].
+///    * If `x` is equivalent to a negative number in modular arithmetic, the result is in [-m+1, 0].
+///
+/// 2. (x % m + m): By adding `m`, we shift the result into a positive range.
+///    * If `x` was already positive, the range becomes [m, 2m-1].
+///    * If `x` was negative, the range becomes [0, m-1], which is our desired range.
+///
+/// 3. ((x % m + m) % m): Taking modulo `m` again ensures the result is in the desired range [0, m-1],
+///    thereby guaranteeing a non-negative result that's also less than `m`.
+pub(crate) fn multiplicative_inverse(a: I256, m: I256) -> Option<I256> {
+    let (g, x, _) = extended_euclidean(a, m);
+    if g != I256::ONE {
+        // a and m are not coprime, thus a doesn't have an inverse modulo m
+        None
+    } else {
+        Some((x % m + m) % m)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_basic_extended_eucledian() {
+    fn test_basic_extended_euclidean() {
         // Given
         let a = I256::from(240u64);
         let b = I256::from(46u64);
@@ -31,13 +65,13 @@ mod tests {
         let (g, s, t) = extended_euclidean(a, b);
 
         // Then
-        assert_eq!(g, I256::from(2u64));
-        assert_eq!(s, I256::from(-9i64));
-        assert_eq!(t, I256::from(47u64));
+        assert_eq!(I256::from(2u64), g);
+        assert_eq!(I256::from(-9i64), s);
+        assert_eq!(I256::from(47u64), t);
     }
 
     #[test]
-    fn test_complex_extended_eucledian() {
+    fn test_complex_extended_euclidean() {
         // Given
         let a = I256::from(6543211245u64);
         let b = I256::from(123456785u64);
@@ -46,8 +80,59 @@ mod tests {
         let (g, s, t) = extended_euclidean(a, b);
 
         // Then
-        assert_eq!(g, I256::from(5u64));
-        assert_eq!(s, I256::from(6850346u64));
-        assert_eq!(t, I256::from(-363068429i64));
+        assert_eq!(I256::from(5u64), g);
+        assert_eq!(I256::from(6850346u64), s);
+        assert_eq!(I256::from(-363068429i64), t);
+    }
+
+    #[test]
+    fn test_basic_multiplicative_inverse() {
+        // Given
+        let a = I256::from(3u64);
+        let m = I256::from(7u64);
+
+        // When
+        let inverse = multiplicative_inverse(a, m);
+
+        // Then
+        assert_eq!(Some(I256::from(5u64)), inverse); // 3*5 % 7 == 1
+    }
+
+    #[test]
+    fn test_no_multiplicative_inverse() {
+        // Given
+        let a = I256::from(2u64);
+        let m = I256::from(4u64); // 2 and 4 are not co-prime
+
+        // When
+        let inverse = multiplicative_inverse(a, m);
+
+        // Then
+        assert_eq!(None, inverse);
+    }
+
+    #[test]
+    fn test_edge_case_multiplicative_inverse() {
+        // Given
+        let a = I256::from(1u64);
+        let m = I256::from(17u64);
+
+        // When
+        let inverse = multiplicative_inverse(a, m);
+
+        // Then
+        assert_eq!(inverse, Some(I256::from(1u64))); // The inverse of 1 mod anything is 1
+
+        // Given
+        let a = I256::from(-1i64);
+        let m = I256::from(17u64);
+
+        // When
+        //// Convert the negative value to its positive modular equivalent.
+        //// For a negative value 'a', its positive modular equivalent is 'a+m'.
+        let inverse = multiplicative_inverse(a + m, m);
+
+        // Then
+        assert_eq!(Some(I256::from(16u64)), inverse); // The inverse of -1 mod 17 is 16
     }
 }


### PR DESCRIPTION
In implementing division for polynomials, I wanted to implement an inverse method on the FieldElement type. In doing so I added some tests and have two failing cases when we try to assert 

\[ (\text{multiplicative inverse of PRIME - 1}) \times (\text{PRIME - 1}) \equiv 1 \mod \text{PRIME} \]

currently, two tests are failing:

- `test_inverse_of_negative_one`
- `test_multiplication_near_boundary` 

I propose that `test_multiplication_near_boundary` error is more fundamental than `test_inverse_of_negative_one`

Model behind the `test_multiplication_near_boundary` test:

Using saturating_mul helps us simulate the multiplication operation without the risk of overflow. If the result from saturating_mul isn't the maximum representable value for the type (indicating saturation), it confirms that the result is indeed representable in the underlying type.

Comparing this result with our custom Mul implementation then serves as a direct check: If they don't match, it means our custom multiplication (Mul implementation) is not handling the operation correctly, even though the result is representable in the type without any overflow.