### PR TITLE
feat: proof stream

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,10 +13,17 @@ runtimes:
     - node@18.12.1
     - python@3.10.8
 lint:
+  definitions:
+    - name: clippy
+      commands:
+        - run: cargo clippy --message-format json --locked --workspace
+            --all-features --all-targets -- -W clippy::all -W clippy::nursery
+            --cap-lints=warn --no-deps -D warnings
+      run_timeout: 20m
   enabled:
     - actionlint@1.6.26
     - checkov@2.5.6
-    - clippy@1.65.0
+    - clippy@SYSTEM
     - git-diff-check
     - osv-scanner@1.4.1
     - prettier@3.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "generic-array 1.0.0",
+ "rand",
  "ruint",
  "serde",
  "serde-big-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -222,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,7 +242,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -254,7 +263,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -279,16 +288,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "eyre"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
-dependencies = [
- "indenter",
- "once_cell",
-]
 
 [[package]]
 name = "fastrlp"
@@ -327,6 +326,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -371,12 +379,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -754,6 +756,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +780,13 @@ name = "stark-anat"
 version = "0.1.0"
 dependencies = [
  "blake2",
- "eyre",
- "rand",
+ "generic-array 1.0.0",
  "ruint",
  "serde",
  "serde-big-array",
  "serde_derive",
+ "sha2",
+ "thiserror",
 ]
 
 [[package]]
@@ -817,18 +831,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ serde_derive = "1.0.189"
 serde-big-array = "0.5.1"
 
 thiserror = "1.0.50"
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eyre = "0.6.8"
-ruint = "1.10.1"
-rand = "0.8.5"
 blake2 = "0.10.6"
+sha2 = "0.10.8"
+
+generic-array = "1.0.0"
+ruint = "1.10.1"
+
 serde = "1.0.189"
 serde_derive = "1.0.189"
 serde-big-array = "0.5.1"
+
+thiserror = "1.0.50"

--- a/src/iop/types/merkle.rs
+++ b/src/iop/types/merkle.rs
@@ -180,10 +180,10 @@ mod test {
         let leaves: Vec<_> = (0..N).map(|_| random_leaf()).collect();
         let tree = MerkleTree::commit(&leaves);
 
-        for i in 0..N {
+        leaves.iter().enumerate().for_each(|(i, leaf)| {
             let path = tree.open(i);
-            assert!(tree.verify(leaves[i], &path, i));
-        }
+            assert!(tree.verify(*leaf, &path, i));
+        });
     }
 
     #[test]
@@ -231,10 +231,10 @@ mod test {
         let leaves: Vec<_> = (0..N).map(|_| random_leaf()).collect();
         let tree = MerkleTree::commit(&leaves);
         let fake_tree = MerkleTree::commit(&vec![random_leaf(); N]);
-        for i in 0..N {
+        leaves.iter().enumerate().for_each(|(i, leaf)| {
             let path = tree.open(i);
-            assert!(!fake_tree.verify(leaves[i], &path, i));
-        }
+            assert!(!fake_tree.verify(*leaf, &path, i));
+        });
     }
 
     fn test_random_leaf_with_original_path(tree: &MerkleTree) {
@@ -253,31 +253,31 @@ mod test {
     }
 
     fn test_original_leaf_with_different_path_index(tree: &MerkleTree, leaves: &[MerkleHash]) {
-        for i in 0..N {
+        leaves.iter().enumerate().for_each(|(i, leaf)| {
             let path = tree.open(i);
             let j = get_different_index(i);
-            assert!(!tree.verify(leaves[i], &path, j));
-        }
+            assert!(!tree.verify(*leaf, &path, j));
+        });
     }
 
     fn test_with_changed_root(tree: &mut MerkleTree, leaves: &[MerkleHash]) {
         let original_root = tree.root;
-        for i in 0..N {
+        leaves.iter().enumerate().for_each(|(i, leaf)| {
             let path = tree.open(i);
             tree.root = random_leaf();
-            assert!(!tree.verify(leaves[i], &path, i));
-        }
+            assert!(!tree.verify(*leaf, &path, i));
+        });
         tree.root = original_root;
     }
 
     fn test_with_tampered_path(tree: &MerkleTree, leaves: &[MerkleHash]) {
-        for i in 0..N {
+        leaves.iter().enumerate().for_each(|(i, leaf)| {
             let path = tree.open(i);
             for j in 0..path.len() {
                 let mut fake_path = path.clone();
                 fake_path[j] = random_leaf();
-                assert!(!tree.verify(leaves[i], &fake_path, i));
+                assert!(!tree.verify(*leaf, &fake_path, i));
             }
-        }
+        });
     }
 }

--- a/src/iop/types/merkle.rs
+++ b/src/iop/types/merkle.rs
@@ -19,7 +19,7 @@ impl From<[u8; 64]> for MerkleHash {
 }
 
 impl MerkleHash {
-    pub fn as_bytes(&self) -> &[u8; 64] {
+    pub const fn as_bytes(&self) -> &[u8; 64] {
         &self.inner
     }
 }
@@ -88,12 +88,12 @@ impl MerkleTree {
             // If our desired leaf is in the left half...
             if current_index < mid {
                 // Add the root of the right half to the results.
-                results.push(MerkleTree::commit(&current_slice[mid..]).root);
+                results.push(Self::commit(&current_slice[mid..]).root);
                 // Narrow our focus to the left half.
                 current_slice = &current_slice[..mid];
             } else {
                 // Otherwise, add the root of the left half to the results.
-                results.push(MerkleTree::commit(&current_slice[..mid]).root);
+                results.push(Self::commit(&current_slice[..mid]).root);
                 // Narrow our focus to the right half and adjust the current index.
                 current_slice = &current_slice[mid..];
                 current_index -= mid;

--- a/src/iop/types/merkle.rs
+++ b/src/iop/types/merkle.rs
@@ -155,7 +155,7 @@ impl MerkleTree {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use rand::{rngs::OsRng, Rng};
 

--- a/src/iop/types/mod.rs
+++ b/src/iop/types/mod.rs
@@ -1,1 +1,2 @@
 pub mod merkle;
+pub mod proof_stream;

--- a/src/iop/types/proof_stream.rs
+++ b/src/iop/types/proof_stream.rs
@@ -1,0 +1,220 @@
+use std::{fmt::Debug, mem};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+type ProofStreamResult<T> = Result<T, ProofStreamError>;
+
+#[derive(Debug, Error)]
+pub enum ProofStreamError {
+    #[error("Read index is out of bounds")]
+    OutOfBoundsReadIndexError,
+}
+
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct ProofStream<S: Serialize> {
+    items: Vec<S>,
+    read_index: usize,
+}
+
+impl<S: Serialize + Clone + Debug> ProofStream<S> {
+    pub fn push(&mut self, item: S) {
+        self.items.push(item);
+    }
+
+    pub fn pull(&mut self) -> ProofStreamResult<&S> {
+        if self.read_index >= self.items.len() {
+            return Err(ProofStreamError::OutOfBoundsReadIndexError);
+        }
+        let val = &self.items[self.read_index];
+        self.read_index += 1;
+        Ok(val)
+    }
+
+    pub fn serialize(&mut self) -> &[u8] {
+        serialize_inner(&self.items)
+    }
+
+    pub fn deserialize(items: &[u8]) -> Self {
+        let items: &[S] = unsafe {
+            core::slice::from_raw_parts(
+                items as *const [u8] as *const S,
+                items.len() / mem::size_of::<S>(),
+            )
+        };
+        Self {
+            items: items.to_vec(),
+            read_index: 0,
+        }
+    }
+
+    pub fn prover_fiat_shamir(&mut self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(&mut self.serialize().to_vec());
+        hasher.finalize().into()
+    }
+
+    pub fn verifier_fiat_shamir(&mut self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        let items = &self.items[0..self.read_index];
+        hasher.update(&mut serialize_inner(items).to_vec());
+        hasher.finalize().into()
+    }
+}
+
+const fn serialize_inner<T>(items: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            (items as *const [T]) as *const u8,
+            mem::size_of::<T>() * items.len(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_derive::Serialize;
+
+    use super::*;
+
+    #[derive(Serialize, Clone, Default, PartialEq, Eq, Debug)]
+    struct TestStruct {
+        pub a: u8,
+        pub b: u8,
+    }
+
+    #[derive(Serialize, Clone, Default, PartialEq, Eq, Debug)]
+    struct TestStructComplex {
+        pub a: Vec<u8>,
+        pub b: u8,
+        pub c: TestStruct,
+    }
+
+    #[test]
+    fn test_serialize_inner() {
+        // Given
+        let items = vec![
+            TestStruct { a: 1, b: 2 },
+            TestStruct { a: 2, b: 3 },
+            TestStruct { a: 3, b: 4 },
+            TestStruct { a: 4, b: 5 },
+        ];
+
+        // When
+        let serialized = serialize_inner(&items);
+
+        // Then
+        let expected = vec![1, 2, 2, 3, 3, 4, 4, 5];
+        assert_eq!(serialized, expected.as_slice());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        // Given
+        let mut ps = ProofStream::default();
+        ps.push(TestStruct { a: 1, b: 2 });
+        ps.push(TestStruct { a: 2, b: 3 });
+        ps.push(TestStruct { a: 3, b: 4 });
+        ps.push(TestStruct { a: 4, b: 5 });
+
+        let serialized = ps.serialize();
+
+        // When
+        let deserialized = ProofStream::<TestStruct>::deserialize(serialized);
+
+        // Then
+        assert_eq!(ps, deserialized);
+    }
+
+    #[test]
+    fn test_deserialize_complex() {
+        // Given
+        let mut ps = ProofStream::default();
+        ps.push(TestStructComplex {
+            a: vec![1, 2, 3, 4],
+            b: 5,
+            c: TestStruct { a: 6, b: 7 },
+        });
+        ps.push(TestStructComplex {
+            a: vec![8, 9, 10, 11],
+            b: 12,
+            c: TestStruct { a: 13, b: 14 },
+        });
+        ps.push(TestStructComplex {
+            a: vec![15, 16, 17, 18],
+            b: 19,
+            c: TestStruct { a: 20, b: 21 },
+        });
+        ps.push(TestStructComplex {
+            a: vec![22, 23, 24, 25],
+            b: 26,
+            c: TestStruct { a: 27, b: 28 },
+        });
+
+        let serialized = ps.serialize();
+
+        // When
+        let deserialized = ProofStream::<TestStructComplex>::deserialize(serialized);
+
+        // Then
+        assert_eq!(ps, deserialized);
+    }
+
+    #[test]
+    fn test_prover_fiat_shamir() {
+        // Given
+        let mut ps = ProofStream::default();
+        ps.push(TestStruct { a: 1, b: 2 });
+        ps.push(TestStruct { a: 2, b: 3 });
+        ps.push(TestStruct { a: 3, b: 4 });
+        ps.push(TestStruct { a: 4, b: 5 });
+
+        // When
+        let fs = ps.prover_fiat_shamir();
+
+        // Then
+        // Made using
+        // ```
+        // from hashlib import sha256
+        // h = sha256()
+        // h.update(bytes([1,2,2,3,3,4,4,5]))
+        // list(h.digest())
+        // ````
+        let expected = [
+            93, 42, 1, 224, 75, 233, 101, 227, 125, 162, 216, 6, 228, 174, 108, 97, 47, 133, 105,
+            139, 185, 172, 216, 9, 111, 253, 76, 41, 218, 63, 129, 104,
+        ];
+        assert_eq!(fs, expected);
+    }
+
+    #[test]
+    fn test_verifier_fiat_shamir() {
+        // Given
+        let mut ps = ProofStream::default();
+        ps.push(TestStruct { a: 1, b: 2 });
+        ps.push(TestStruct { a: 2, b: 3 });
+        ps.push(TestStruct { a: 3, b: 4 });
+        ps.push(TestStruct { a: 4, b: 5 });
+
+        // When
+        ps.pull().unwrap();
+        ps.pull().unwrap();
+        ps.pull().unwrap();
+        let fs = ps.verifier_fiat_shamir();
+
+        // Then
+        // Made using
+        // ```
+        // from hashlib import sha256
+        // h = sha256()
+        // h.update(bytes([1,2,2,3,3,4]))
+        // list(h.digest())
+        // ````
+        let expected = [
+            75, 202, 77, 187, 114, 48, 150, 65, 196, 29, 129, 127, 207, 1, 44, 173, 19, 244, 179,
+            187, 59, 51, 209, 6, 10, 103, 150, 249, 200, 234, 12, 42,
+        ];
+        assert_eq!(fs, expected);
+    }
+}


### PR DESCRIPTION
Adds the proof stream, based on the python code from [anatomy of a stark](https://aszepieniec.github.io/stark-anatomy/basic-tools#the-fiat-shamir-transform). 

Makes use of unsafe code for serializing and deserializing. 

In order to serialize `&[T]`, we cast it to a raw pointer `*const u8`, and then pass the length as `size_in_bytes(T) * len(&[T])`. 
In order to deserialize `&[u8]` into `&[T]`, we cast it to a raw pointer `*const u8`, and then pass the length as `len(&[u8]) / size_in_bytes(T)`. 